### PR TITLE
Location service only sends UPD message after first TCP message

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -25,8 +25,8 @@ typing_event.user.serverId = "server456" #Static value, must be replaced if nece
 
 # LiveLocation Payload
 live_location = messenger_pb2.LiveLocation()
-typing_event.user.userId = "user123" #Static value, must be replaced if necessary
-typing_event.user.serverId = "server456" #Static value, must be replaced if necessary
+live_location.user.userId = "user123" #Static value, must be replaced if necessary
+live_location.user.serverId = "server456" #Static value, must be replaced if necessary
 
 
 


### PR DESCRIPTION
1. Update location_service.py 1.1 When receiving the first UDP live location of a client, only the TCP chatmessage is sent. Only afterwards UDP LIveLocations messages are forwarded 1.2 Added a new function to create live_locations from the data_dict. 1.3 corrected small naming mistakes
1.4 Updated expiry logic (previusly inverted)

2. utils 2.1 naming error typing_event statt live_location